### PR TITLE
Allow running from more envs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "index.js",
   "author": "Vinicius Dacal",
   "private": false,
+  "scripts": {
+    "start": "node ."
+  },
   "dependencies": {
     "body-parser": "^1.14.1",
     "express": "3.4.8",

--- a/public/main.js
+++ b/public/main.js
@@ -1,5 +1,5 @@
 document.addEventListener("DOMContentLoaded", function(event) {
-  var socket = io.connect('127.0.0.1:3000', {
+  var socket = io.connect(window.location.hostname, {
     query: 'notificationKey=NOTIFICATION_KEY'
   });
   socket.on('NEW_NOTIFICATION', function (notification) {


### PR DESCRIPTION
Allows start using `npm start`.
Can now be served from any place.
